### PR TITLE
hashtag comments

### DIFF
--- a/src/tscan.cxx
+++ b/src/tscan.cxx
@@ -2779,6 +2779,12 @@ folia::Document *getFrogResult( istream &is ) {
           continue;
         }
       }
+      
+      // cut off line after ###
+      size_t comment_match = line.find("###");
+      if (comment_match != string::npos) {
+        line = line.substr(0, comment_match);
+      }
     }
     if ( incomment )
       continue;

--- a/src/tscan.cxx
+++ b/src/tscan.cxx
@@ -2764,7 +2764,12 @@ folia::Document *getFrogResult( istream &is ) {
       line = line.substr(0, match);
     }
 
-    //replace weird characters
+    //replace utf-8 BOM
+    if (line.compare(0, 3, "\xEF\xBB\xBF") == 0) {
+      line.erase(0, 3);
+    }
+
+    // replace brackets
     std::regex opening ("[\{\[]");
     line = regex_replace (line, opening, "(");
 

--- a/src/tscan.cxx
+++ b/src/tscan.cxx
@@ -23,6 +23,7 @@
 #include <string>
 #include <fstream>
 #include <cmath>
+#include <regex>
 #include <algorithm>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -2756,11 +2757,23 @@ folia::Document *getFrogResult( istream &is ) {
 #ifdef DEBUG_FROG
     cerr << "read: '" << line << "'" << endl;
 #endif
+
+    // cut off line after ###
+    size_t match = line.find("###");
+    if (match != string::npos) {
+      line = line.substr(0, match);
+    }
+
+    //replace weird characters
+    std::regex opening ("[\{\[]");
+    line = regex_replace (line, opening, "(");
+
+    std::regex closing ("[\\}\\]]");
+    line = regex_replace (line, closing, ")");
+
     if ( line.length() > 2 ) {
       string start = line.substr( 0, 3 );
-      if ( start == "###" )
-        continue;
-      else if ( start == "<<<" ) {
+      if ( start == "<<<" ) {
         if ( incomment ) {
           cerr << "Nested comment (<<<) not allowed!" << endl;
           return 0;
@@ -2778,12 +2791,6 @@ folia::Document *getFrogResult( istream &is ) {
           incomment = false;
           continue;
         }
-      }
-      
-      // cut off line after ###
-      size_t comment_match = line.find("###");
-      if (comment_match != string::npos) {
-        line = line.substr(0, comment_match);
       }
     }
     if ( incomment )


### PR DESCRIPTION
'###' comments no longer need to be on a new line. Anything after ### is ignored

Also replaces {} and [] with ().